### PR TITLE
Do not fail if resource table has not been found.

### DIFF
--- a/src/main/java/net/dongliu/apk/parser/ApkParser.java
+++ b/src/main/java/net/dongliu/apk/parser/ApkParser.java
@@ -186,13 +186,16 @@ public class ApkParser implements Closeable {
     private void parseResourceTable() throws IOException {
         ZipArchiveEntry resourceEntry = getEntry(AndroidConstants.RESOURCE_FILE);
         if (resourceEntry == null) {
-            throw new ParserException("resource table not found");
+            // if no resource entry has been found, we assume it is not needed by this APK
+            this.resourceTable = new ResourceTable();
+            this.locales = Collections.EMPTY_SET;
+        } else {
+            ResourceTableParser resourceTableParser = new ResourceTableParser(zf.getInputStream(
+                resourceEntry));
+            resourceTableParser.parse();
+            this.resourceTable = resourceTableParser.getResourceTable();
+            this.locales = resourceTableParser.getLocales();
         }
-        ResourceTableParser resourceTableParser = new ResourceTableParser(
-                zf.getInputStream(resourceEntry));
-        resourceTableParser.parse();
-        this.resourceTable = resourceTableParser.getResourceTable();
-        this.locales = resourceTableParser.getLocales();
     }
 
     /**


### PR DESCRIPTION
With this patch, ApkParser will not throw a `ParserException` by default if
a resource table has not been found. Instead, it will initialize the
resource table with an empty object, and the locale set with an empty set.
This fixes the bug #6 with SmokeTest and other system apps.
