### PR TITLE
Fix endless recursion while trying to localize non-string resources

### DIFF
--- a/src/main/java/net/dongliu/apk/parser/utils/ParseUtils.java
+++ b/src/main/java/net/dongliu/apk/parser/utils/ParseUtils.java
@@ -310,12 +310,16 @@ public class ParseUtils {
                 continue;
             }
             ref = resource.getKey();
-            int level = Locales.match(locale, type.getLocale());
-            if (level == 2) {
-                result = resource.toStringValue(resourceTable, locale);
+            if (typeSpec.getName().equals("string")) {
+                int level = Locales.match(locale, type.getLocale());
+                if (level == 2) {
+                    result = resource.toStringValue(resourceTable, locale);
+                    break;
+                } else if (level > currentLevel) {
+                    result = resource.toStringValue(resourceTable, locale);
+                }
+            } else {
                 break;
-            } else if (level > currentLevel) {
-                result = resource.toStringValue(resourceTable, locale);
             }
         }
         if (locale == null || result == null) {


### PR DESCRIPTION
Localizing non-string resources does not make a lot of sense: e.g. it will
yield something like "res/drawable-xxxhdpi/icon" instead of
"@drawable/icon", which would be perfectly okay. Apart from this, some APKs
cause the search for the proper "localized" non-string to run into an
endless recursion. This patch fixes this issue by only translating string
resources, and ignoring localization on everything else, effectively
yielding "@type/ref" format. This allows parsing the properly localized app
title from the manifest.